### PR TITLE
Use Services global variable if possible

### DIFF
--- a/src/api/experiments.js
+++ b/src/api/experiments.js
@@ -3,7 +3,9 @@
 
 'use strict';
 
-let { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+let Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 let { ExtensionSupport } = ChromeUtils.import(
   'resource:///modules/ExtensionSupport.jsm'
 );

--- a/src/content/customcol.js
+++ b/src/content/customcol.js
@@ -47,7 +47,9 @@ let { AppConstants } = ChromeUtils.import(
   'resource://gre/modules/AppConstants.jsm'
 );
 // @ts-ignore
-let { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+let Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 const thunvatarDateColumnHandler = {
   init(win) {


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and also available in all system globals from version 104 https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 , and those code doesn't have to import Services.jsm for recent versions.